### PR TITLE
Fix release workflow: strip only the 'v' prefix from the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set tag without first two chars
+      - name: Strip v prefix from tag
         id: tag
         run: |
-          SHORT_TAG="${GITHUB_REF_NAME:2}"
+          SHORT_TAG="${GITHUB_REF_NAME#v}"
           echo "SHORT_TAG=$SHORT_TAG" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary

The v2.0.0 release Docker build failed with:

```
ERROR: failed to build: invalid tag "poliuscorp/retrox:.0.0": invalid reference format
```

`${GITHUB_REF_NAME:2}` is a bash substring starting at index 2, which on a tag like `v2.0.0` produces `.0.0` (it skips both `v` and `2`). The intent was to strip only the leading `v`. This switches to `${GITHUB_REF_NAME#v}`, which removes a leading `v` if present and leaves the rest untouched.

For `v2.0.0` the workflow will now publish:
- `poliuscorp/retrox:2.0.0`
- `poliuscorp/retrox:latest`

## Test plan

- [ ] Merge this PR
- [ ] Re-run the failed `Release` workflow run for `v2.0.0` (`gh run rerun 25599785571` or via the Actions UI)
- [ ] Confirm `poliuscorp/retrox:2.0.0` and `:latest` appear on Docker Hub

## Note (not addressed here)

The same workflow run also surfaced a Node.js 20 deprecation notice for `actions/checkout@v4`, `docker/build-push-action@v6`, etc. That's a warning with a June 2026 cutoff — happy to do that as a separate PR if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)