### PR TITLE
ci: auto-merge Dependabot PRs for patch and minor bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,45 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot PRs that bump dependencies by patch or minor.
+# Major bumps are left open for manual review (per the policy in
+# .github/dependabot.yml: "Majors typically carry breaking changes that
+# warrant their own commit and changelog read.").
+#
+# For grouped updates, the metadata action returns the highest semver
+# bump in the group. Since groups in dependabot.yml are scoped to
+# patch + minor only, every group PR resolves to at most "minor" and
+# is therefore eligible for auto-merge.
+#
+# Prerequisites (configure once in the repo settings):
+#   1. Settings > General > "Allow auto-merge" must be enabled.
+#   2. Branch protection on `main` should require the backend / frontend
+#      CI checks. Without protection, --auto merges immediately with no
+#      CI gate.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and enable auto-merge for patch / minor bumps
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-auto-merge.yml`. When Dependabot opens a PR:

- **Patch / minor bump** → workflow approves it and enables auto-merge (squash). It will merge as soon as required CI checks pass.
- **Major bump** → workflow does nothing. The PR stays open for manual review, matching the policy already documented in `.github/dependabot.yml` (*"Majors typically carry breaking changes that warrant their own commit and changelog read."*).
- **Grouped PRs** → the `dependabot/fetch-metadata` action returns the highest semver level in the group. Since every group in `dependabot.yml` is scoped to `patch` + `minor` only, every grouped PR resolves to at most `minor` and is therefore eligible.

## Required follow-up (repo settings — I can't change these)

Two settings need to be flipped for this to actually work:

1. **Settings → General → Pull Requests → "Allow auto-merge"** is currently **off**. Turn it on.
2. **Settings → Branches → Branch protection rules → `main`** — currently no protection. Add a rule that requires the relevant CI workflow runs (e.g. `backend.yml` and `frontend.yml`) to pass before merging.
   - Without this, `--auto` merges immediately with no CI gate. Probably not what you want.

## Effect on the 5 already-open Dependabot PRs

| PR | Type | Will auto-merge? |
|----|------|---|
| #11 `deps: bump the backend-deps group in /backend with 6 updates` | grouped (patch/minor) | **Yes** |
| #12 `deps: bump bcrypt from 4.2.1 to 5.0.0 in /backend` | major (4 → 5) | No — manual |
| #10 `ci: bump actions/setup-node from 4 to 6` | major (4 → 6) | No — manual |
| #9  `ci: bump docker/setup-buildx-action from 3 to 4` | major (3 → 4) | No — manual |
| #8  `ci: bump docker/build-push-action from 6 to 7` | major (6 → 7) | No — manual |

The auto-merge workflow only runs on *new* PR events, so existing open PRs aren't retroactively processed unless Dependabot rebases them. To trigger it on the open #11, you can comment `@dependabot rebase` on it after merging this PR — that closes/reopens with a new PR-event the workflow will hook into.

## Test plan

- [ ] Merge this PR
- [ ] Enable "Allow auto-merge" in repo settings
- [ ] Add branch protection on `main` requiring CI checks
- [ ] Comment `@dependabot rebase` on PR #11; confirm it auto-approves and merges after CI passes
- [ ] Confirm the 4 major-bump PRs are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)