### PR TITLE
Fix eslint warnings and bump actions/checkout to v5

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,7 +11,7 @@ jobs:
     name: ruff
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v4

--- a/frontend/js/gamepad-nav.js
+++ b/frontend/js/gamepad-nav.js
@@ -57,7 +57,6 @@
  *      requests fullscreen BEFORE the module finishes loading. Hoist
  *      `indicator`, `playHint`, `persistor` to the top of play.js. */
 
-import { openPalette } from "./command-palette.js";
 import { rememberControllerSeen } from "./input-mode.js";
 import { canGoBackInApp } from "./router.js";
 
@@ -436,12 +435,6 @@ function suspendHeldDirectionsForNav() {
 }
 window.addEventListener("retrox:navigated", suspendHeldDirectionsForNav);
 window.addEventListener("popstate", suspendHeldDirectionsForNav);
-
-function focusLibraryLink() {
-  const lib = document.querySelector('.sidebar [data-key="library"]')
-           || document.querySelector('.sidebar [href="/games"]');
-  if (lib) focusElement(lib);
-}
 
 // "Back" gesture for the controller. Goes back ONE in-app step when
 // there's somewhere safe to go (i.e. another app page is in the


### PR DESCRIPTION
## Summary

Two issues surfaced by the latest CI runs, fixed together.

### eslint errors in `frontend/js/gamepad-nav.js`

```
'focusLibraryLink' is defined but never used. Allowed unused vars must match /^_/u
'openPalette'      is defined but never used. Allowed unused vars must match /^_/u
```

Both are genuinely dead code:
- `openPalette` is imported but never called in `gamepad-nav.js` (it's used in `shell.js` and `command-palette.js`, which import it directly).
- `focusLibraryLink` is defined but referenced nowhere in the codebase.

Deleted both rather than renaming with `_` prefix — dead code shouldn't be carried forward.

### `actions/checkout@v4` Node.js 20 deprecation warning

```
Node.js 20 actions are deprecated. The following actions are running on
Node.js 20 and may not work as expected: actions/checkout@v4.
```

Bumped `actions/checkout@v4` → `@v5` in all three workflows (backend, frontend, release). v5 runs on Node.js 24, clearing the warning ahead of the June 2026 cutoff.

## Test plan

- [x] `npm run lint` passes locally with zero warnings
- [ ] Frontend workflow runs cleanly on this PR (eslint + no Node 20 warning)
- [ ] Backend workflow runs cleanly (no Node 20 warning)
- [ ] Next release workflow run uses checkout@v5 (verified after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)